### PR TITLE
Implement GetArchive

### DIFF
--- a/repo_file.go
+++ b/repo_file.go
@@ -13,3 +13,11 @@ import (
 func (c *Client) GetFile(user, repo, ref, tree string) ([]byte, error) {
 	return c.getResponse("GET", fmt.Sprintf("/repos/%s/%s/raw/%s/%s", user, repo, ref, tree), nil, nil)
 }
+
+// GetArchive downloads the full contents of a repository. Ref can be a branch/tag/commit.
+func (c *Client) GetArchive(user, repo, ref, format string) ([]byte, error) {
+	if format != ".zip" && format != ".tar.gz" {
+		return nil, fmt.Errorf("Invalid format: %s (Must be .zip or .tar.gz)", format)
+	}
+	return c.getResponse("GET", fmt.Sprintf("/repos/%s/%s/archive/%s%s", user, repo, ref, format), nil, nil)
+}


### PR DESCRIPTION
Adds a `GetArchive` function for Clients which downloads compressed contents of a repository. This is based on the documentation in the wiki.