### PR TITLE
Add API support for releases and attachments

### DIFF
--- a/attachment.go
+++ b/attachment.go
@@ -1,0 +1,90 @@
+// Copyright 2017 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gogs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"time"
+)
+
+// Attachment a generic attachment
+// swagger:model
+type Attachment struct {
+	ID          int64     `json:"id"`
+	Name        string    `json:"name"`
+	Created     time.Time `json:"created_at"`
+	UUID        string    `json:"uuid"`
+	DownloadURL string    `json:"browser_download_url"`
+}
+
+// ListReleaseAttachments list release's attachments
+func (c *Client) ListReleaseAttachments(user, repo string, release int64) ([]*Attachment, error) {
+	attachments := make([]*Attachment, 0, 10)
+	err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/releases/%d/assets", user, repo, release),
+		nil, nil, &attachments)
+	return attachments, err
+}
+
+// GetReleaseAttachment returns the requested attachment
+func (c *Client) GetReleaseAttachment(user, repo string, release int64, id int64) (*Attachment, error) {
+	a := new(Attachment)
+	err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, release, id),
+		nil, nil, &a)
+	return a, err
+}
+
+// CreateReleaseAttachment creates an attachment for the given release
+func (c *Client) CreateReleaseAttachment(user, repo string, release int64, file io.Reader, filename string) (*Attachment, error) {
+	// Write file to body
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("attachment", filename)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = io.Copy(part, file); err != nil {
+		return nil, err
+	}
+	if err = writer.Close(); err != nil {
+		return nil, err
+	}
+
+	// Send request
+	attachment := new(Attachment)
+	err = c.getParsedResponse("POST",
+		fmt.Sprintf("/repos/%s/%s/releases/%d/assets", user, repo, release),
+		http.Header{"Content-Type": {writer.FormDataContentType()}}, body, &attachment)
+	return attachment, err
+}
+
+// EditReleaseAttachment updates the given attachment with the given options
+func (c *Client) EditReleaseAttachment(user, repo string, release int64, attachment int64, form EditAttachmentOptions) (*Attachment, error) {
+	body, err := json.Marshal(&form)
+	if err != nil {
+		return nil, err
+	}
+	attach := new(Attachment)
+	return attach, c.getParsedResponse("PATCH", fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, release, attachment), jsonHeader, bytes.NewReader(body), attach)
+}
+
+// DeleteReleaseAttachment deletes the given attachment including the uploaded file
+func (c *Client) DeleteReleaseAttachment(user, repo string, release int64, id int64) error {
+	_, err := c.getResponse("DELETE", fmt.Sprintf("/repos/%s/%s/releases/%d/assets/%d", user, repo, release, id), nil, nil)
+	return err
+}
+
+// EditAttachmentOptions options for editing attachments
+// swagger:model
+type EditAttachmentOptions struct {
+	Name string `json:"name"`
+}

--- a/release.go
+++ b/release.go
@@ -5,18 +5,75 @@
 package gogs
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"time"
 )
 
 // Release represents a release API object.
 type Release struct {
-	ID              int64     `json:"id"`
-	TagName         string    `json:"tag_name"`
-	TargetCommitish string    `json:"target_commitish"`
-	Name            string    `json:"name"`
-	Body            string    `json:"body"`
-	Draft           bool      `json:"draft"`
-	Prerelease      bool      `json:"prerelease"`
-	Author          *User     `json:"author"`
-	Created         time.Time `json:"created_at"`
+	ID              int64         `json:"id"`
+	TagName         string        `json:"tag_name"`
+	TargetCommitish string        `json:"target_commitish"`
+	Name            string        `json:"name"`
+	Body            string        `json:"body"`
+	Draft           bool          `json:"draft"`
+	Prerelease      bool          `json:"prerelease"`
+	Author          *User         `json:"author"`
+	Created         time.Time     `json:"created_at"`
+	URL             string        `json:"url"`
+	TarURL          string        `json:"tarball_url"`
+	ZipURL          string        `json:"zipball_url"`
+	Attachments     []*Attachment `json:"assets"`
+}
+
+// ListReleases list releases of a repository
+func (c *Client) ListReleases(user, repo string) ([]*Release, error) {
+	releases := make([]*Release, 0, 10)
+	err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/releases", user, repo),
+		nil, nil, &releases)
+	return releases, err
+}
+
+// GetRelease get a release of a repository
+func (c *Client) GetRelease(user, repo string, id int64) (*Release, error) {
+	r := new(Release)
+	err := c.getParsedResponse("GET",
+		fmt.Sprintf("/repos/%s/%s/releases/%d", user, repo, id),
+		nil, nil, &r)
+	return r, err
+}
+
+// DeleteRelease delete a release from a repository
+func (c *Client) DeleteRelease(user, repo string, id int64) error {
+	_, err := c.getResponse("DELETE",
+		fmt.Sprintf("/repos/%s/%s/releases/%d", user, repo, id),
+		nil, nil)
+	return err
+}
+
+// CreateReleaseOption options when creating a release
+type CreateReleaseOption struct {
+	// required: true
+	TagName      string `json:"tag_name" binding:"Required"`
+	Target       string `json:"target_commitish"`
+	Title        string `json:"name"`
+	Note         string `json:"body"`
+	IsDraft      bool   `json:"draft"`
+	IsPrerelease bool   `json:"prerelease"`
+}
+
+// CreateRelease create a release
+func (c *Client) CreateRelease(user, repo string, form CreateReleaseOption) (*Release, error) {
+	body, err := json.Marshal(form)
+	if err != nil {
+		return nil, err
+	}
+	r := new(Release)
+	err = c.getParsedResponse("POST",
+		fmt.Sprintf("/repos/%s/%s/releases", user, repo),
+		jsonHeader, bytes.NewReader(body), r)
+	return r, err
 }


### PR DESCRIPTION
This PR provides initial API support for releases (get, list, create, delete).