### PR TITLE
New client method: GetSelfInfo()

### DIFF
--- a/user.go
+++ b/user.go
@@ -23,3 +23,9 @@ func (c *Client) GetUserInfo(user string) (*User, error) {
 	err := c.getParsedResponse("GET", fmt.Sprintf("/users/%s", user), nil, nil, u)
 	return u, err
 }
+
+func (c *Client) GetSelfInfo() (*User, error) {
+	u := new(User)
+	err := c.getParsedResponse("GET", "/user", nil, nil, u)
+	return u, err
+}


### PR DESCRIPTION
Uses the GOGS API endpoint "/user" to retrieve the information for the current authenticated user.

This is very useful in a lot of cases where a `gogs.Client` is initialised with a token and the username isn't readily available.  For instance, loading a token from a database for a service that interacts with GOGS.  Since the API endpoint exists, it would be nice for that convenience to be available in the client as well.